### PR TITLE
Fix Vercel build configuration conflict

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,16 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "server.js",
-      "use": "@vercel/node"
+  "functions": {
+    "server.js": {
+      "includeFiles": "public/**,src/**"
     }
-  ],
+  },
   "routes": [
     {
       "src": "/(.*)",
       "dest": "/server.js"
     }
   ],
-  "functions": {
-    "server.js": {
-      "includeFiles": "public/**,src/**"
-    }
-  },
   "env": {
     "NODE_ENV": "production"
   }


### PR DESCRIPTION
Resolves #4

Fixed the Vercel deployment error by removing the conflicting `builds` property from vercel.json. The configuration now uses only the `functions` property, which is the recommended approach.

**Changes:**
- Removed conflicting `builds` array
- Kept `functions` configuration for better feature support
- Maintained routing and environment configurations

Generated with [Claude Code](https://claude.ai/code)