### PR TITLE
fix: update Vercel configuration for proper static file serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,24 +1,12 @@
 {
   "version": 2,
+  "builds": [
+    {
+      "src": "server.js",
+      "use": "@vercel/node"
+    }
+  ],
   "routes": [
-    {
-      "src": "/js/(.*)",
-      "dest": "/public/js/$1",
-      "headers": {
-        "Content-Type": "application/javascript"
-      }
-    },
-    {
-      "src": "/css/(.*)",
-      "dest": "/public/css/$1"
-    },
-    {
-      "src": "/src/combat/(.*)",
-      "dest": "/src/combat/$1",
-      "headers": {
-        "Content-Type": "application/javascript"
-      }
-    },
     {
       "src": "/(.*)",
       "dest": "/server.js"


### PR DESCRIPTION
Fixes Vercel deployment issue where three.js was not rendering due to incorrect static file routing.

Changes:
- Updated vercel.json to use @vercel/node runtime
- Simplified routes to let Express handle static files
- Removed problematic manual routing configuration

Fixes #6

Generated with [Claude Code](https://claude.ai/code)